### PR TITLE
Update urls to use 'ropsten' not 'uat'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-REACT_APP_ROPSTEN_LINK_URL=https://link.uat.x.immutable.com
-REACT_APP_ROPSTEN_ENV_URL=https://api.uat.x.immutable.com/v1
+REACT_APP_ROPSTEN_LINK_URL=https://link.ropsten.x.immutable.com
+REACT_APP_ROPSTEN_ENV_URL=https://api.ropsten.x.immutable.com/v1
 REACT_APP_ROPSTEN_STARK_CONTRACT_ADDRESS=0x4527be8f31e2ebfbef4fcaddb5a17447b27d2aef
 REACT_APP_ROPSTEN_REGISTRATION_ADDRESS=0x6C21EC8DE44AE44D0992ec3e2d9f1aBb6207D864
 


### PR DESCRIPTION
@calvwang9 @samueltan-immutable 
This just changes the URL's for this default example so that they are not seeing the redirect.